### PR TITLE
More explicit doc for custom button list styles

### DIFF
--- a/demo/pages/advanced-use.vue
+++ b/demo/pages/advanced-use.vue
@@ -889,7 +889,7 @@ onUnmounted(() => {
           </p>
           <p>
             Theoretically, you do not need to provide a button element. However, it is recommended to do so, since it will optimize the user experience a lot (like focusing the element on closing the modal, etc.).<br />
-            If you provide a specific button, you can also choose between the overlay-dropdown list or the modal (default) style. Latter one is strongly recommended.
+            If you provide a specific button, you can only choose between the "overlay" list style or the "modal" (default) style. Latter one is strongly recommended.
           </p>
           <h3 class="mb-3 mt-8">{{ $t('content.guide.step1') }}: Import</h3>
           <p>


### PR DESCRIPTION
## Type(s) of changes

<!--- What types of changes does your code introduce? Remove the lines, that do not apply -->

- **(Bug) fix** <!--- (non-breaking change which fixes an issue) -->

Not really a bug fix, but none of the other options apply. Maybe you should add **Doc**  to your PR template.

## Description of the change

<!--- Describe your changes and why it was important to do it -->

The previous wording is not explicit enough and I was was wondering why the dropdown style was not applied.

I understood only by looking at the code at https://github.com/add2cal/add-to-calendar-button/blob/63e9e5f6fe7ce1aa437e7d00472cc2094c655d67/src/atcb-init.js#L478-L481


Maybe you could also limit the options available in typescript:

https://github.com/add2cal/add-to-calendar-button/blob/63e9e5f6fe7ce1aa437e7d00472cc2094c655d67/index.d.ts#L59


## Checklist

<!--- Go over all the following points, and put an `x` in the boxes. -->

- [x] My code follows the code style of this project (I at least ran `npm run format`).
- [x] I have read the **CONTRIBUTING** document.

<!--- Pull requests should be thought of as a conversation. There will be some back and forth when trying to get code merged into this or any other project. With all but the simplest changes you can and should expect that the maintainers of the project will request changes to your code. Please be aware of that and check in after you open your PR in order to get your code merged in cleanly.

Thanks! -->
