### PR TITLE
Increase email validation length to support google calendar emails

### DIFF
--- a/src/atcb-validate.js
+++ b/src/atcb-validate.js
@@ -209,7 +209,7 @@ async function atcb_validate_availability(data, msgPrefix, i, msgSuffix) {
 async function atcb_validate_organizer(data, msgPrefix, i, msgSuffix) {
   if (data.dates[`${i}`].organizer && data.dates[`${i}`].organizer !== '') {
     const organizerParts = data.dates[`${i}`].organizer.split('|');
-    if (organizerParts.length !== 2 || organizerParts[0].length > 50 || organizerParts[1].length > 80 || !atcb_validEmail(organizerParts[1])) {
+    if (organizerParts.length !== 2 || organizerParts[0].length > 50 || organizerParts[1].length > 100 || !atcb_validEmail(organizerParts[1])) {
       throw new Error(msgPrefix + ' failed: organizer needs to match the schema "NAME|EMAIL" with a valid email address' + msgSuffix);
     }
   }
@@ -228,7 +228,7 @@ async function atcb_validate_attendee(data, msgPrefix, i, msgSuffix) {
     if (attendeeParts.length === 1 && atcb_validEmail(attendeeParts[0])) {
       return true;
     }
-    if (attendeeParts.length !== 2 || attendeeParts[0].length > 50 || attendeeParts[1].length > 80 || !atcb_validEmail(attendeeParts[1])) {
+    if (attendeeParts.length !== 2 || attendeeParts[0].length > 50 || attendeeParts[1].length > 100 || !atcb_validEmail(attendeeParts[1])) {
       throw new Error(msgPrefix + ' failed: attendee needs to be a valid email address or match the schema "NAME|EMAIL" with EMAIL being a valid email address' + msgSuffix);
     }
   }


### PR DESCRIPTION
## Type(s) of changes

<!--- What types of changes does your code introduce? Remove the lines, that do not apply -->

- **(Bug) fix** 

## Description of the change

You cannot use custom google calendars as organizer. Additional Google Calendar emails are long and look like this:
c_6745f58b4d80d12c7d81b98ba112eec40ea99c21f24b27ba8c56d302bba0255c@group.calendar.google.com. These types of emails do not validate because they are longer than the arbitrary 80 character limit here whereas these emails are 92. I increased the limit to 100 incase google calendar emails fluctuate in length over the 92 in the example.



...

## Checklist


- [x] My code follows the code style of this project (I at least ran `npm run format`).
- [x] I have read the **CONTRIBUTING** document.

