### PR TITLE
fix: Add Shift+Tab support for backward navigation in dropdown lists

### DIFF
--- a/src/atcb-init.js
+++ b/src/atcb-init.js
@@ -887,10 +887,20 @@ function atcb_global_listener_keydown(event) {
       if (event.key === 'ArrowDown' && currFocusOption.dataset.optionNumber < optionListCount) {
         targetFocus = parseInt(currFocusOption.dataset.optionNumber) + 1;
       } else if (event.key === 'Tab') {
-        if (currFocusOption.dataset.optionNumber < optionListCount) {
-          targetFocus = parseInt(currFocusOption.dataset.optionNumber) + 1;
+        if (event.shiftKey) {
+          // Shift+Tab: navigate backwards
+          if (currFocusOption.dataset.optionNumber > 1) {
+            targetFocus = parseInt(currFocusOption.dataset.optionNumber) - 1;
+          } else {
+            targetFocus = optionListCount;
+          }
         } else {
-          targetFocus = 1;
+          // Tab: navigate forwards
+          if (currFocusOption.dataset.optionNumber < optionListCount) {
+            targetFocus = parseInt(currFocusOption.dataset.optionNumber) + 1;
+          } else {
+            targetFocus = 1;
+          }
         }
       } else if (event.key === 'ArrowUp' && currFocusOption.dataset.optionNumber >= 1) {
         targetFocus = parseInt(currFocusOption.dataset.optionNumber) - 1;


### PR DESCRIPTION
## Description

Fixes #734 - Adds Shift+Tab support for backward navigation in dropdown lists

This PR implements proper reverse keyboard navigation using Shift+Tab in the Add to Calendar Button dropdown lists, addressing an accessibility gap where users could only navigate forward with Tab.

## Changes Made

- **Enhanced `atcb_global_listener_keydown` function** in `src/atcb-init.js`
- **Added `event.shiftKey` detection** to distinguish between Tab and Shift+Tab
- **Implemented backward navigation logic** when Shift+Tab is pressed
- **Maintained wrap-around behavior** at list boundaries for both directions
- **Preserved existing forward navigation** functionality

## Behavior

### Before
- **Tab**: Navigate forward through options ✅
- **Shift+Tab**: No effect ❌ 
- **Arrow Up/Down**: Navigate up/down ✅

### After  
- **Tab**: Navigate forward through options ✅
- **Shift+Tab**: Navigate backward through options ✅
- **Arrow Up/Down**: Navigate up/down ✅
- **Wrap-around**: Both Tab and Shift+Tab wrap at boundaries ✅

## Accessibility Impact

This change improves W3C WAI compliance by implementing standard keyboard navigation patterns that users expect. Users can now navigate in both directions through calendar options, which is essential for accessibility.

## Testing

- [x] Tested forward navigation with Tab
- [x] Tested backward navigation with Shift+Tab  
- [x] Tested wrap-around behavior at list boundaries
- [x] Verified existing Arrow key navigation still works
- [x] Ran `npm run format` for code style compliance

## Related Issue

Closes #734

---

**Note**: This PR follows the contributing guidelines by branching from `dev` and targets the `dev` branch for merging.