### PR TITLE
fix(demo): recover playground initialization

### DIFF
--- a/demo/components/playground/playgroundArea.vue
+++ b/demo/components/playground/playgroundArea.vue
@@ -6,25 +6,43 @@ import LayoutAttrs from "@/components/playground/attrs/layoutAttrs.vue";
 import { mapAttrsObject, attrsToHtmlString } from '@/utils/attrs';
 import { set, LSKey } from '@/utils/localStorage';
 import { getInitialAttrs, getInitialAttrsBlank } from '@/utils/attrs/default';
-import { isbot } from "isbot";
 const LazyCodeBlock = defineAsyncComponent(() => import('@/components/codeBlock.vue'));
 const { t, locale } = useI18n();
 
 const showCode = ref(false);
 const showMC = ref(false);
-const loaded = ref(false);
-const isBot = ref<boolean>(true);
-if (import.meta.client) {
-  isBot.value = isbot(navigator.userAgent);
-}
+const loadingState = ref<'loading' | 'ready' | 'error'>('loading');
+const loaded = computed(() => loadingState.value === 'ready');
+const LOAD_TIMEOUT = 5000;
+let loadAttempt = 0;
 
 const data = ref( getInitialAttrsBlank() );
 
 async function loadAtcbScript () {
-  import('add-to-calendar-button').then(() => {
-    loaded.value = true;
-    return;
-  });
+  const attempt = ++loadAttempt;
+  loadingState.value = 'loading';
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => reject(new Error('Timed out loading Add to Calendar Button')), LOAD_TIMEOUT);
+
+      import('add-to-calendar-button').then(() => {
+        window.clearTimeout(timeout);
+        resolve();
+      }).catch((error) => {
+        window.clearTimeout(timeout);
+        reject(error);
+      });
+    });
+
+    if (attempt === loadAttempt) {
+      loadingState.value = 'ready';
+    }
+  } catch {
+    if (attempt === loadAttempt) {
+      loadingState.value = 'error';
+    }
+  }
 }
 
 if (import.meta.client) {
@@ -45,10 +63,9 @@ if (import.meta.client) {
     }
   });
 
-  // load atcb script
-  if (!isBot.value) {
+  onMounted(() => {
     loadAtcbScript();
-  }
+  });
 }
 </script>
 
@@ -72,6 +89,12 @@ if (import.meta.client) {
       >
         <div class="sticky top-[30vh] z-30 h-auto w-full py-10 xs:w-fit md:h-[500px] md:py-0">
           <add-to-calendar-button v-if="loaded" v-bind="mapAttrsObject(data)" debug hideRichData hideBranding />
+          <div v-else-if="loadingState === 'error'" class="mx-auto max-w-xs text-center text-sm text-zinc-600 dark:text-zinc-400" role="alert">
+            <p>{{ $t('labels.playgroundLoadError') }}</p>
+            <button class="mt-4 rounded bg-primary px-4 py-2 font-semibold text-white hover:bg-primary-light" type="button" @click="loadAtcbScript">
+              {{ $t('labels.retry') }}
+            </button>
+          </div>
           <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="mx-auto h-16 w-16 animate-spin text-primary">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>

--- a/demo/i18n/locales/de.json
+++ b/demo/i18n/locales/de.json
@@ -33,6 +33,8 @@
     "clickHereLearnMore": "Hier klicken und mehr erfahren",
     "showCode": "Quellcode anzeigen",
     "hideCode": "Quellcode ausblenden",
+    "playgroundLoadError": "Der Testbereich konnte nicht geladen werden. Bitte versuche es erneut.",
+    "retry": "Erneut versuchen",
     "dateInput": "Termin-Details",
     "layoutInput": "Layout-Einstellungen",
     "demo": "Demo",

--- a/demo/i18n/locales/en.json
+++ b/demo/i18n/locales/en.json
@@ -33,6 +33,8 @@
     "clickHereLearnMore": "Click here to learn more",
     "showCode": "Show source code",
     "hideCode": "Hide source code",
+    "playgroundLoadError": "The Playground could not be loaded. Please try again.",
+    "retry": "Try again",
     "dateInput": "Date Details",
     "layoutInput": "Layout Settings",
     "demo": "Demo",

--- a/demo/nuxt.config.ts
+++ b/demo/nuxt.config.ts
@@ -23,7 +23,6 @@ export default defineNuxtConfig({
         '@heroicons/vue/24/solid',
         '@headlessui/vue',
         '@heroicons/vue/20/solid',
-        'isbot',
         'timezones-ical-library',
         'vue-marquee-text-component', // CJS
         'shiki',

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -20,7 +20,6 @@
         "@nuxtjs/sitemap": "^8.2.2",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "@vite-pwa/nuxt": "^1.1.1",
-        "isbot": "^5.1.44",
         "nuxt": "^4.4.8",
         "nuxt-headlessui": "^1.2.2",
         "nuxt-schema-org": "^6.2.3",
@@ -53,7 +52,8 @@
       }
     },
     "..": {
-      "version": "2.14.0",
+      "name": "add-to-calendar-button",
+      "version": "2.15.0",
       "license": "ELv2",
       "dependencies": {
         "timezones-ical-library": "^2.2.1"
@@ -4163,31 +4163,11 @@
         }
       }
     },
-    "node_modules/@nuxt/cli/node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@nuxt/cli/node_modules/citty": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
-    },
-    "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@nuxt/cli/node_modules/std-env": {
       "version": "4.1.0",
@@ -10463,21 +10443,6 @@
         }
       }
     },
-    "node_modules/devframe/node_modules/crossws": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.9.tgz",
-      "integrity": "sha512-iWx+1OMSG2aOHpjyf9AESOzkwsVdS49cXM9dVrI2PDhxU5l2RIWE/KG56gk4BbAnsMoycvniJ9OnOxO9LRzHVA==",
-      "extraneous": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "srvx": ">=0.11.5"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/devframe/node_modules/h3": {
       "version": "2.0.1-rc.22",
       "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
@@ -13434,15 +13399,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
-    },
-    "node_modules/isbot": {
-      "version": "5.1.44",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.44.tgz",
-      "integrity": "sha512-PGEHtwMnKbZpeSEXW2Utx+/JWed7dp6DiH0WWg33vGSDA7RUvpUeJSVlLrVkQ1RCpvDOUc/eH9ql7VsdbBZ8pA==",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -54,7 +54,6 @@
     "@nuxtjs/sitemap": "^8.2.2",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@vite-pwa/nuxt": "^1.1.1",
-    "isbot": "^5.1.44",
     "nuxt": "^4.4.8",
     "nuxt-headlessui": "^1.2.2",
     "nuxt-schema-org": "^6.2.3",


### PR DESCRIPTION
## Summary
- Initialize the Playground client import for every browser, including HeadlessChrome.
- Replace the permanent spinner with a five-second timeout, localized recoverable error, and retry action.
- Remove the no-longer-used isbot dependency and Vite optimization entry.

## Verification
- npm ci (root and demo)
- npm run type-check (demo)
- npm run lint (demo)
- npm run prettier (demo)
- npm run build:demo
- HeadlessChrome local smoke: 0 disabled desktop controls after six seconds; Subject edit updated the Add to Calendar preview.

## Test constraint
npm run test built the root package but browser tests could not launch because this host lacks a usable Chromium sandbox. The --puppeteer fallback is unavailable because @web/test-runner-puppeteer is not a project dependency. No demo component-test infrastructure exists, so no source-coupled regression test was added.