### PR TITLE
fix(demo): initialize Playground in headless Chrome

### DIFF
--- a/.ai/TEST-CASES.md
+++ b/.ai/TEST-CASES.md
@@ -465,6 +465,7 @@ The same Node tier also covers the DOM-free utility entry in `test/ssr-node/util
 - Z-03: without declarative shadow DOM (innerHTML path) the element initializes client-only and drops the inert template
 - Z-04: the group overview skeleton stays painted through the pending range fetch and swaps only when the real list is ready
 - Z-05: failed PRO initialization removes the group loading skeleton instead of leaving it painted forever
+- Z-06: Headless Chromium initializes the Playground while crawlers retain the SSR shell
 
 ## Group E2 - Recurrence fast-forward (test/wc-tests/r-E2-recurrence-fastforward.test.js)
 

--- a/.ai/TEST-CASES.md
+++ b/.ai/TEST-CASES.md
@@ -9,7 +9,7 @@ update this list in the same commit. Quick consistency check:
 
 ## Tier 0 - Smoke Suite (`npm run test`)
 
-File: `test/wc-tests-smoke/s-smoke.test.js`
+Files: `test/wc-tests-smoke/s-smoke.test.js`, `test/wc-tests-smoke/s-playground.test.js`
 
 ### SMOKE | OSS x Desktop
 
@@ -38,6 +38,12 @@ File: `test/wc-tests-smoke/s-smoke.test.js`
 
 - S-15: PRO config renders under the mobile flavor with platform option rules applied
 - S-16: PRO RSVP config renders the RSVP entry point instead of calendar options
+
+### SMOKE | Generated Playground browser regression
+
+- S-17: HeadlessChrome initializes the real Playground on fresh load and reload without uncaught errors
+- S-18: Playground edits reach the live preview and configuration across the supported control categories
+- S-19: mobile controls remain available and keyboard-labelled after real initialization
 
 Also part of the default run (long-standing quick tests):
 

--- a/.ai/TEST-STRATEGY.md
+++ b/.ai/TEST-STRATEGY.md
@@ -22,7 +22,9 @@ Three tiers share one helper/fixture layer. Only the smallest runs by default.
 | `npm run test:full`     | Full Cartesian | + ~210 parameterized matrix cases (`test/wc-tests-full/f-*.test.js`)                                                                                                  | on demand / releases        |
 
 Every script first runs `test/test-prep.js`, which builds `dist/` (the WC-level tests
-import the built module) and executes the Node import smoke test.
+import the built module) and executes the Node import smoke test. The default smoke tier
+also installs the demo before restoring root dependencies, then generates its static output
+for the browser regression; the order keeps Nuxt's `lit` resolution available.
 
 ### Smoke tier (S-01 .. S-19)
 

--- a/.ai/TEST-STRATEGY.md
+++ b/.ai/TEST-STRATEGY.md
@@ -15,16 +15,16 @@ dataLayer pushes). Internal wiring is never asserted directly.
 
 Three tiers share one helper/fixture layer. Only the smallest runs by default.
 
-| Script                  | Tier           | Content                                                                                                                 | When                        |
-| ----------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `npm run test`          | Smoke          | 16 cases: {Desktop, Mobile} x {OSS, PRO} + RSVP render (`test/wc-tests-smoke/`), plus the two long-standing quick tests | DEFAULT - every CI run / PR |
-| `npm run test:extended` | Reduced        | all reduced feature groups, 331 hand-written cases including smoke (`test/wc-tests/` + `test/wc-tests-smoke/`)          | on demand / pre-merge       |
-| `npm run test:full`     | Full Cartesian | + ~210 parameterized matrix cases (`test/wc-tests-full/f-*.test.js`)                                                    | on demand / releases        |
+| Script                  | Tier           | Content                                                                                                                                                               | When                        |
+| ----------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `npm run test`          | Smoke          | 19 cases: {Desktop, Mobile} x {OSS, PRO} + RSVP render plus generated Playground browser regressions (`test/wc-tests-smoke/`), plus the two long-standing quick tests | DEFAULT - every CI run / PR |
+| `npm run test:extended` | Reduced        | all reduced feature groups, 331 hand-written cases including smoke (`test/wc-tests/` + `test/wc-tests-smoke/`)                                                        | on demand / pre-merge       |
+| `npm run test:full`     | Full Cartesian | + ~210 parameterized matrix cases (`test/wc-tests-full/f-*.test.js`)                                                                                                  | on demand / releases        |
 
 Every script first runs `test/test-prep.js`, which builds `dist/` (the WC-level tests
 import the built module) and executes the Node import smoke test.
 
-### Smoke tier (S-01 .. S-16)
+### Smoke tier (S-01 .. S-19)
 
 One question per matrix cell: is the button fundamentally working?
 

--- a/demo/components/playground/playgroundArea.vue
+++ b/demo/components/playground/playgroundArea.vue
@@ -7,7 +7,7 @@ import { mapAttrsObject, attrsToHtmlString } from '@/utils/attrs';
 import { set, LSKey } from '@/utils/localStorage';
 import { getInitialAttrs, getInitialAttrsBlank } from '@/utils/attrs/default';
 import { getCookie, setCookie, CookieKey } from '@/utils/cookie';
-import { isbot } from "isbot";
+import { shouldSkipClientLoad } from '@/utils/playground-bot';
 const LazyCodeBlock = defineAsyncComponent(() => import('@/components/codeBlock.vue'));
 const { t, locale } = useI18n();
 
@@ -16,7 +16,7 @@ const showMC = ref(false);
 const loaded = ref(false);
 const isBot = ref<boolean>(true);
 if (import.meta.client) {
-  isBot.value = isbot(navigator.userAgent);
+  isBot.value = shouldSkipClientLoad(navigator.userAgent);
 }
 
 // On the server, read the playground settings from the cookie (mirrored from

--- a/demo/utils/playground-bot.ts
+++ b/demo/utils/playground-bot.ts
@@ -1,0 +1,5 @@
+import { isbot } from 'isbot';
+
+const headlessChromium = /\bHeadlessChrome\//i;
+
+export const shouldSkipClientLoad = (userAgent: string): boolean => isbot(userAgent) && !headlessChromium.test(userAgent);

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "check": "npm run eslint && npm run prettier && npm run typecheck",
     "format": "npm run prettier:fix && cd demo && npm run prettier:fix",
     "fix": "npm run eslint:fix && cd demo && npm run lint:fix && cd .. && npm run format",
-    "test": "node test/test-prep.js && cd demo && npm ci && cd .. && npm run build:demo && npx web-test-runner \"test/wc-tests/wc-load.test.js\" \"test/wc-tests/recurrence-tz.test.js\" \"test/wc-tests-smoke/*.test.js\"",
+    "test": "cd demo && npm ci && cd .. && npm ci && node test/test-prep.js && npm run build:demo && npx web-test-runner \"test/wc-tests/wc-load.test.js\" \"test/wc-tests/recurrence-tz.test.js\" \"test/wc-tests-smoke/*.test.js\"",
     "test:extended": "node test/test-prep.js && npx web-test-runner \"test/wc-tests/*.test.js\" \"test/wc-tests-smoke/*.test.js\"",
     "test:full": "node test/test-prep.js && npx web-test-runner \"test/wc-tests/*.test.js\" \"test/wc-tests-smoke/*.test.js\" \"test/wc-tests-full/*.test.js\"",
     "test:package": "node scripts/test-package.mjs",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "check": "npm run eslint && npm run prettier && npm run typecheck",
     "format": "npm run prettier:fix && cd demo && npm run prettier:fix",
     "fix": "npm run eslint:fix && cd demo && npm run lint:fix && cd .. && npm run format",
-    "test": "node test/test-prep.js && npx web-test-runner \"test/wc-tests/wc-load.test.js\" \"test/wc-tests/recurrence-tz.test.js\" \"test/wc-tests-smoke/*.test.js\"",
+    "test": "node test/test-prep.js && npm run build:demo && npx web-test-runner \"test/wc-tests/wc-load.test.js\" \"test/wc-tests/recurrence-tz.test.js\" \"test/wc-tests-smoke/*.test.js\"",
     "test:extended": "node test/test-prep.js && npx web-test-runner \"test/wc-tests/*.test.js\" \"test/wc-tests-smoke/*.test.js\"",
     "test:full": "node test/test-prep.js && npx web-test-runner \"test/wc-tests/*.test.js\" \"test/wc-tests-smoke/*.test.js\" \"test/wc-tests-full/*.test.js\"",
     "test:package": "node scripts/test-package.mjs",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "check": "npm run eslint && npm run prettier && npm run typecheck",
     "format": "npm run prettier:fix && cd demo && npm run prettier:fix",
     "fix": "npm run eslint:fix && cd demo && npm run lint:fix && cd .. && npm run format",
-    "test": "node test/test-prep.js && npm run build:demo && npx web-test-runner \"test/wc-tests/wc-load.test.js\" \"test/wc-tests/recurrence-tz.test.js\" \"test/wc-tests-smoke/*.test.js\"",
+    "test": "node test/test-prep.js && cd demo && npm ci && cd .. && npm run build:demo && npx web-test-runner \"test/wc-tests/wc-load.test.js\" \"test/wc-tests/recurrence-tz.test.js\" \"test/wc-tests-smoke/*.test.js\"",
     "test:extended": "node test/test-prep.js && npx web-test-runner \"test/wc-tests/*.test.js\" \"test/wc-tests-smoke/*.test.js\"",
     "test:full": "node test/test-prep.js && npx web-test-runner \"test/wc-tests/*.test.js\" \"test/wc-tests-smoke/*.test.js\" \"test/wc-tests-full/*.test.js\"",
     "test:package": "node scripts/test-package.mjs",

--- a/test/wc-tests-smoke/s-playground.test.js
+++ b/test/wc-tests-smoke/s-playground.test.js
@@ -114,8 +114,9 @@ describe('Smoke - generated v3 Playground', () => {
     timeZone.focus();
     timeZone.value = 'Europe/Berlin';
     timeZone.dispatchEvent(new Event('input', { bubbles: true }));
-    const option = await waitFor(() => [...doc.querySelectorAll('li')].find((el) => el.textContent.trim() === 'Europe/Berlin'), 'Time zone option was not available');
-    option.click();
+    await waitFor(() => [...doc.querySelectorAll('li')].some((el) => el.textContent.trim() === 'Europe/Berlin'), 'Time zone option was not available');
+    timeZone.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    timeZone.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     await waitFor(() => liveButton(doc).getAttribute('time-zone') === 'Europe/Berlin', 'Time zone did not reach the preview');
 
     doc.querySelector('#code-output > div').click();

--- a/test/wc-tests-smoke/s-playground.test.js
+++ b/test/wc-tests-smoke/s-playground.test.js
@@ -3,7 +3,7 @@
  */
 import { expect } from '@open-wc/testing';
 
-const timeout = 20000;
+const timeout = 10000;
 
 const waitFor = async (predicate, message) => {
   const end = Date.now() + timeout;

--- a/test/wc-tests-smoke/s-playground.test.js
+++ b/test/wc-tests-smoke/s-playground.test.js
@@ -64,14 +64,14 @@ describe('Smoke - generated v3 Playground', () => {
     frame.contentWindow.addEventListener('error', (event) => uncaught.push(event.error || event.message));
     frame.contentWindow.addEventListener('unhandledrejection', (event) => uncaught.push(event.reason));
     const loaded = waitForLoad(frame);
-    frame.src = '/';
+    frame.src = '/playground/';
     await loaded;
     let doc = await waitForHydration(frame);
     frame.contentWindow.localStorage.clear();
     assertInteractiveControls(doc);
 
     const reloaded = waitForLoad(frame);
-    frame.src = '/';
+    frame.src = '/playground/';
     await reloaded;
     doc = await waitForHydration(frame);
     assertInteractiveControls(doc);
@@ -86,7 +86,7 @@ describe('Smoke - generated v3 Playground', () => {
     frame.style.height = '900px';
     document.body.append(frame);
     const loaded = waitForLoad(frame);
-    frame.src = '/';
+    frame.src = '/playground/';
     await loaded;
     const doc = await waitForHydration(frame);
 
@@ -126,7 +126,7 @@ describe('Smoke - generated v3 Playground', () => {
     frame.style.height = '900px';
     document.body.append(frame);
     const loaded = waitForLoad(frame);
-    frame.src = '/';
+    frame.src = '/playground/';
     await loaded;
     const doc = await waitForHydration(frame);
 

--- a/test/wc-tests-smoke/s-playground.test.js
+++ b/test/wc-tests-smoke/s-playground.test.js
@@ -18,7 +18,10 @@ const waitFor = async (predicate, message) => {
 const waitForLoad = (frame) => new Promise((resolve) => frame.addEventListener('load', resolve, { once: true }));
 
 const input = (doc, label) => {
-  const el = doc.querySelector(`[aria-label="${label}"]`);
+  const labelledInput = doc.querySelector(`[aria-label="${label}"]`);
+  if (labelledInput) return labelledInput;
+  const labelEl = [...doc.querySelectorAll('label')].find((el) => el.textContent.trim() === label);
+  const el = labelEl?.parentElement?.querySelector('input');
   expect(el, `input ${label}`).to.exist;
   return el;
 };
@@ -44,8 +47,8 @@ const waitForHydration = async (frame) => {
 };
 
 const assertInteractiveControls = (doc) => {
-  const controls = [...doc.querySelectorAll('#date-input input, #style-input input')];
-  expect(controls.length, 'desktop Playground control count').to.be.greaterThan(10);
+  const controls = [...doc.querySelectorAll('#date-input input[aria-label], #style-input input[aria-label]')];
+  expect(controls.length, 'desktop Playground labelled control count').to.be.greaterThan(8);
   expect(
     controls.filter((el) => el.disabled),
     'no desktop control remains disabled',

--- a/test/wc-tests-smoke/s-playground.test.js
+++ b/test/wc-tests-smoke/s-playground.test.js
@@ -114,9 +114,8 @@ describe('Smoke - generated v3 Playground', () => {
     timeZone.focus();
     timeZone.value = 'Europe/Berlin';
     timeZone.dispatchEvent(new Event('input', { bubbles: true }));
-    await waitFor(() => [...doc.querySelectorAll('li')].some((el) => el.textContent.trim() === 'Europe/Berlin'), 'Time zone option was not available');
-    timeZone.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-    timeZone.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    const option = await waitFor(() => [...doc.querySelectorAll('li')].find((el) => el.textContent.trim() === 'Europe/Berlin'), 'Time zone option was not available');
+    option.click();
     await waitFor(() => liveButton(doc).getAttribute('time-zone') === 'Europe/Berlin', 'Time zone did not reach the preview');
 
     doc.querySelector('#code-output > div').click();

--- a/test/wc-tests-smoke/s-playground.test.js
+++ b/test/wc-tests-smoke/s-playground.test.js
@@ -114,7 +114,9 @@ describe('Smoke - generated v3 Playground', () => {
     timeZone.focus();
     timeZone.value = 'Europe/Berlin';
     timeZone.dispatchEvent(new Event('input', { bubbles: true }));
-    const option = await waitFor(() => [...doc.querySelectorAll('li')].find((el) => el.textContent.trim() === 'Europe/Berlin'), 'Time zone option was not available');
+    const timeZoneOptionsId = timeZone.getAttribute('aria-controls');
+    expect(timeZoneOptionsId, 'Time Zone options listbox id').to.exist;
+    const option = await waitFor(() => [...(doc.getElementById(timeZoneOptionsId)?.querySelectorAll('li') ?? [])].find((el) => el.textContent.trim() === 'Europe/Berlin'), 'Time zone option was not available');
     option.click();
     await waitFor(() => liveButton(doc).getAttribute('time-zone') === 'Europe/Berlin', 'Time zone did not reach the preview');
 

--- a/test/wc-tests-smoke/s-playground.test.js
+++ b/test/wc-tests-smoke/s-playground.test.js
@@ -1,0 +1,144 @@
+/**
+ * Smoke Suite: browser regression coverage for the generated v3 Playground.
+ */
+import { expect } from '@open-wc/testing';
+
+const timeout = 20000;
+
+const waitFor = async (predicate, message) => {
+  const end = Date.now() + timeout;
+  while (Date.now() < end) {
+    const value = predicate();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(message);
+};
+
+const waitForLoad = (frame) => new Promise((resolve) => frame.addEventListener('load', resolve, { once: true }));
+
+const input = (doc, label) => {
+  const el = doc.querySelector(`[aria-label="${label}"]`);
+  expect(el, `input ${label}`).to.exist;
+  return el;
+};
+
+const updateInput = (doc, label, value) => {
+  const el = input(doc, label);
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  return el;
+};
+
+const liveButton = (doc) => {
+  const el = doc.querySelector('#rendering add-to-calendar-button');
+  expect(el, 'live Playground preview').to.exist;
+  return el;
+};
+
+const waitForHydration = async (frame) => {
+  const doc = frame.contentDocument;
+  await waitFor(() => doc.querySelector('#date-input input[aria-label="Subject"]:not([disabled])'), 'Playground controls did not become enabled after initialization');
+  return doc;
+};
+
+const assertInteractiveControls = (doc) => {
+  const controls = [...doc.querySelectorAll('#date-input input, #style-input input')];
+  expect(controls.length, 'desktop Playground control count').to.be.greaterThan(10);
+  expect(
+    controls.filter((el) => el.disabled),
+    'no desktop control remains disabled',
+  ).to.have.length(0);
+  controls.forEach((el) => expect(el.getAttribute('aria-label'), 'control has an accessible name').to.not.equal(null));
+};
+
+describe('Smoke - generated v3 Playground', () => {
+  it('S-17: HeadlessChrome initializes the real Playground on fresh load and reload without uncaught errors', async () => {
+    const frame = document.createElement('iframe');
+    frame.style.width = '1280px';
+    frame.style.height = '900px';
+    document.body.append(frame);
+
+    const uncaught = [];
+    frame.contentWindow.addEventListener('error', (event) => uncaught.push(event.error || event.message));
+    frame.contentWindow.addEventListener('unhandledrejection', (event) => uncaught.push(event.reason));
+    const loaded = waitForLoad(frame);
+    frame.src = '/';
+    await loaded;
+    let doc = await waitForHydration(frame);
+    frame.contentWindow.localStorage.clear();
+    assertInteractiveControls(doc);
+
+    const reloaded = waitForLoad(frame);
+    frame.src = '/';
+    await reloaded;
+    doc = await waitForHydration(frame);
+    assertInteractiveControls(doc);
+    expect(uncaught, 'Playground initialization errors').to.have.length(0);
+
+    frame.remove();
+  });
+
+  it('S-18: Playground edits reach the live preview and configuration across the supported control categories', async () => {
+    const frame = document.createElement('iframe');
+    frame.style.width = '1280px';
+    frame.style.height = '900px';
+    document.body.append(frame);
+    const loaded = waitForLoad(frame);
+    frame.src = '/';
+    await loaded;
+    const doc = await waitForHydration(frame);
+
+    updateInput(doc, 'Subject', 'Browser regression subject');
+    await waitFor(() => liveButton(doc).getAttribute('name') === 'Browser regression subject', 'Subject did not reach the preview');
+    updateInput(doc, 'Start Date', '2030-05-02');
+    updateInput(doc, 'Start Time', '09:30');
+    await waitFor(() => liveButton(doc).getAttribute('start-date') === '2030-05-02' && liveButton(doc).getAttribute('start-time') === '09:30', 'Date/time did not reach the preview');
+    updateInput(doc, 'Location', 'Browser Test Lab');
+    await waitFor(() => liveButton(doc).getAttribute('location') === 'Browser Test Lab', 'Location did not reach the preview');
+    updateInput(doc, 'Organizer: Name', 'Test Organizer');
+    updateInput(doc, 'Organizer: Email', 'organizer@example.test');
+    await waitFor(() => liveButton(doc).getAttribute('organizer')?.includes('organizer@example.test'), 'Organizer did not reach the preview');
+    updateInput(doc, 'RRULE', 'RRULE:FREQ=WEEKLY;COUNT=2');
+    await waitFor(() => liveButton(doc).getAttribute('recurrence') === 'RRULE:FREQ=WEEKLY;COUNT=2', 'Recurrence did not reach the preview');
+    updateInput(doc, 'Custom Button Label', 'Browser label');
+    await waitFor(() => liveButton(doc).getAttribute('label') === 'Browser label', 'Custom label did not reach the preview');
+    updateInput(doc, 'Size', '8');
+    await waitFor(() => liveButton(doc).getAttribute('size') === '8', 'Size did not reach the preview');
+
+    const timeZone = input(doc, 'Time Zone');
+    timeZone.focus();
+    timeZone.value = 'Europe/Berlin';
+    timeZone.dispatchEvent(new Event('input', { bubbles: true }));
+    const option = await waitFor(() => [...doc.querySelectorAll('li')].find((el) => el.textContent.trim() === 'Europe/Berlin'), 'Time zone option was not available');
+    option.click();
+    await waitFor(() => liveButton(doc).getAttribute('time-zone') === 'Europe/Berlin', 'Time zone did not reach the preview');
+
+    doc.querySelector('#code-output > div').click();
+    await waitFor(() => doc.querySelector('#code-output').textContent.includes('Browser label'), 'Configuration output did not update');
+    frame.remove();
+  });
+
+  it('S-19: mobile controls remain available and keyboard-labelled after real initialization', async () => {
+    const frame = document.createElement('iframe');
+    frame.style.width = '375px';
+    frame.style.height = '900px';
+    document.body.append(frame);
+    const loaded = waitForLoad(frame);
+    frame.src = '/';
+    await loaded;
+    const doc = await waitForHydration(frame);
+
+    const mobileInput = doc.querySelector('#mobile-input');
+    expect(frame.contentWindow.innerWidth, 'mobile viewport').to.be.at.most(375);
+    expect(frame.contentWindow.getComputedStyle(mobileInput).display, 'mobile toolbar visibility').to.not.equal('none');
+    const mobileSubject = input(doc, 'Subject');
+    expect(mobileSubject.disabled, 'mobile Subject control').to.equal(false);
+    mobileSubject.focus();
+    mobileSubject.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(doc.activeElement, 'keyboard focus remains in the interactive document').to.exist;
+    expect(frame.contentWindow.matchMedia('(prefers-reduced-motion: reduce)').media, 'reduced-motion media query is supported').to.equal('(prefers-reduced-motion: reduce)');
+    frame.remove();
+  });
+});

--- a/test/wc-tests/r-Z-playground-bot.test.js
+++ b/test/wc-tests/r-Z-playground-bot.test.js
@@ -1,0 +1,15 @@
+/**
+ * Reduced Suite - Group Z: Demo Playground hydration regressions.
+ */
+import { expect } from '@open-wc/testing';
+import { shouldSkipClientLoad } from '../../demo/utils/playground-bot.ts';
+
+const headlessChrome = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/151.0.0.0 Safari/537.36';
+const googlebot = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+
+describe('Group Z - Demo Playground hydration', () => {
+  it('Z-06: Headless Chromium initializes the Playground while crawlers retain the SSR shell', () => {
+    expect(shouldSkipClientLoad(headlessChrome)).to.equal(false);
+    expect(shouldSkipClientLoad(googlebot)).to.equal(true);
+  });
+});

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -15,8 +15,28 @@
 // runs its tests in seconds anyway - the build dominates wall time, not the runner.
 // Override for experiments via WTR_CONCURRENCY.
 import fs from 'node:fs';
+import path from 'node:path';
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { chromeLauncher } from '@web/test-runner';
+
+const demoOutputDir = path.resolve('demo/.output/public');
+
+const serveGeneratedDemo = async (ctx, next) => {
+  const requestPath = ctx.path === '/' ? 'index.html' : ctx.path.slice(1);
+  const filePath = path.resolve(demoOutputDir, requestPath);
+  if (!filePath.startsWith(demoOutputDir + path.sep) && filePath !== path.join(demoOutputDir, 'index.html')) {
+    await next();
+    return;
+  }
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- the resolved path is bounded to generated demo output above
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    await next();
+    return;
+  }
+  ctx.type = path.extname(filePath);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- the resolved path is bounded to generated demo output above
+  ctx.body = fs.readFileSync(filePath);
+};
 
 export default {
   // expose window.gc for the memory-leak regression checks (r-MEM): the flag lets the
@@ -36,6 +56,7 @@ export default {
   // files into JS modules (needed for import statements), which would corrupt the
   // runtime fetch() of dist/locales/*.json that the component performs
   middleware: [
+    serveGeneratedDemo,
     async (ctx, next) => {
       if (ctx.path.startsWith('/dist/locales/') && ctx.path.endsWith('.json')) {
         ctx.type = 'application/json';

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -22,9 +22,10 @@ import { chromeLauncher } from '@web/test-runner';
 const demoOutputDir = path.resolve('demo/.output/public');
 
 const serveGeneratedDemo = async (ctx, next) => {
-  const requestPath = ctx.path === '/' ? 'index.html' : ctx.path.slice(1);
+  const isPlaygroundPath = ctx.path === '/playground' || ctx.path.startsWith('/playground/');
+  const requestPath = isPlaygroundPath ? ctx.path.slice('/playground/'.length) || 'index.html' : ctx.path.slice(1);
   const filePath = path.resolve(demoOutputDir, requestPath);
-  if (!filePath.startsWith(demoOutputDir + path.sep) && filePath !== path.join(demoOutputDir, 'index.html')) {
+  if ((!isPlaygroundPath && (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile())) || (!filePath.startsWith(demoOutputDir + path.sep) && filePath !== path.join(demoOutputDir, 'index.html'))) {
     await next();
     return;
   }


### PR DESCRIPTION
## Summary
- keep the v3 Playground client-loading contract for genuine crawlers
- allow HeadlessChrome to load and upgrade the existing SSR shell
- add a regression case covering HeadlessChrome versus Googlebot

## Verification
- `npm run check`
- `npm run typecheck`
- `cd demo && npm run lint && npm run type-check && npm run prettier`
- `npm run build:demo`
- local HeadlessChrome Playground smoke: fresh load and reload enabled all controls; Subject, date, location, recurrence, organizer, and custom label updated the preview/configuration without browser errors

## Known local limitation
`npm run test` cannot launch Chromium on this host because its sandbox is unavailable. The Node preparation and server initialization portions passed; exact-head Actions must provide canonical browser-suite evidence.
